### PR TITLE
[Docs] Fix typos: contibution → contribution, comitting → committing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
 Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
 

--- a/guides/your-first-pr-checklist.md
+++ b/guides/your-first-pr-checklist.md
@@ -2,7 +2,7 @@
 
 Before you click "Create pull request," walk through this checklist. It catches the things that turn a clean merge into three rounds of review.
 
-## Pre-flight: before comitting
+## Pre-flight: before committing
 
 ### The change itself
 


### PR DESCRIPTION
## Summary

Fixes two typos in documentation:

1. **README.md**: `contibution` → `contribution` (subtitle blockquote)
2. **guides/your-first-pr-checklist.md**: `comitting` → `committing` (section heading)

## Changes

- `README.md`: replaced misspelled word in blockquote
- `guides/your-first-pr-checklist.md`: fixed heading typo

## Completes

- Closes #1
- Closes #5

## How to verify

1. Check the blockquote in README.md reads "contribution"
2. Check the heading in your-first-pr-checklist.md reads "committing"
3. No other text was modified
