### PR TITLE
Fix typo: contribution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
 Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
 


### PR DESCRIPTION
## Summary

- Fix the typo `contibution` in the README subtitle.

## Validation

- `git diff --check upstream/main..HEAD`
- `rg -n "contibution" README.md` returned no matches.

Closes #1
