### PR TITLE
Add Total TypeScript link to curated links

### DIFF
--- a/resources/python/curated-links.md
+++ b/resources/python/curated-links.md
@@ -15,6 +15,7 @@ Open a PR following [CONTRIBUTING.md](../../CONTRIBUTING.md). Branch name: `add-
 ## Learning the language
 
 - [Python Official Tutorial](https://docs.python.org/3/tutorial/) — The canonical introduction, written by the Python core team.
+- [Total TypeScript](https://www.totaltypescript.com/) — Free and paid tutorials focused on practical TypeScript patterns and the type system.
 
 ## Beginner-friendly project lists
 


### PR DESCRIPTION
Added a link to Total TypeScript for TypeScript tutorials.

## What does this PR do?

This PR adds a new link to the resources list.

## Is this your first open source contribution?

- [ ] Yes — welcome! We're glad you're here. 🎉
- [ x] No

## Did you follow CONTRIBUTING.md?

- [ x] I claimed the issue in a comment before starting
- [x ] My branch follows the naming convention (`add-resource/...`, `fix-typo/...`, etc.)
- [x ] My commit messages are clear and use the imperative form
- [ x] My change does only what the issue asked for — no unrelated edits

## Linked issue

Closes #8 

## Cohort reference (optional)

