### PR TITLE
Fix typo: contibution → contribution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
 Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
 


### PR DESCRIPTION
## Summary

Fixes #1

The subtitle blockquote in `README.md` reads "contibution" (missing the second "r"). It should read "contribution".

## Root Cause

Typo in line 3 of `README.md` — the word "contribution" was misspelled as "contibution" in the blockquote: `> Your guide to making your first open source contibution.`

## Fix

Corrected the spelling: `contibution` → `contribution`.

## Changes

- `README.md`: 1 character inserted, 1 character deleted (`+1 -1` lines)

## Testing

- "contibution" no longer appears in README.md ✅
- No other text in the file was changed ✅
- The fix is limited to a single character correction ✅