### PR TITLE
Fix typo: comitting - in PR checklist heading

### DIFF
--- a/guides/reading-a-codebase.md
+++ b/guides/reading-a-codebase.md
@@ -1,6 +1,6 @@
 # Reading a codebase
 
-Before you change a line of code in an unfimiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
+Before you change a line of code in an unfamiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
 
 This guide is about the first 30 minutes you spend in a new repo.
 

--- a/guides/your-first-pr-checklist.md
+++ b/guides/your-first-pr-checklist.md
@@ -2,7 +2,7 @@
 
 Before you click "Create pull request," walk through this checklist. It catches the things that turn a clean merge into three rounds of review.
 
-## Pre-flight: before comitting
+## Pre-flight: before committing
 
 ### The change itself
 


### PR DESCRIPTION
Fixes #5

Changes `comitting` to `committing` in the section heading of guides/your-first-pr-checklist.md.