### PR TITLE
fix: Fix typo: "unfimiliar" → "unfamiliar" in reading-a-codebase.md

### DIFF
--- a/guides/reading-a-codebase.md
+++ b/guides/reading-a-codebase.md
@@ -1,6 +1,6 @@
 # Reading a codebase
 
-Before you change a line of code in an unfimiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
+Before you change a line of code in an **unfamiliar** codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
 
 This guide is about the first 30 minutes you spend in a new repo.
 


### PR DESCRIPTION
Fixes #4

**Auto-generated by Local Bounty Hunter AI**

This PR addresses the issue: Fix typo: "unfimiliar" → "unfamiliar" in reading-a-codebase.md

_Generated using local LLM (LM Studio)_