### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
-Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
+Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developers go from "I've never merged a PR" to "I just shipped my first contribution."
 
 ## What this repo is
 


### PR DESCRIPTION
Fixed two typos in the README:
- `contibution` → `contribution`
- `developpers` → `developers`

Closes #1
Closes #2