### PR TITLE
fix: correct typo 'comitting' -> 'committing'

### DIFF
--- a/guides/your-first-pr-checklist.md
+++ b/guides/your-first-pr-checklist.md
@@ -2,7 +2,7 @@
 
 Before you click "Create pull request," walk through this checklist. It catches the things that turn a clean merge into three rounds of review.
 
-## Pre-flight: before comitting
+## Pre-flight: before committing
 
 ### The change itself
 


### PR DESCRIPTION
Fixed typo in the 'Your first PR checklist' guide.

Closes #5