### PR TITLE
docs: fix first-contributor guide typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
-Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
+Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developers go from "I've never merged a PR" to "I just shipped my first contribution."
 
 ## What this repo is
 

--- a/guides/finding-good-first-issues.md
+++ b/guides/finding-good-first-issues.md
@@ -59,7 +59,7 @@ Issues with recent comments are safer.
 
 If the repo has no `CONTRIBUTING.md`, no PR template, and no obvious signs anyone has thought about new contributors, you're on your own. That's fine when you're more experienced — for a first PR, prefer repos that have done some of this work.
 
-### Maintainer responsivness
+### Maintainer responsiveness
 
 <!-- TODO: contribution welcome — expand on what good vs slow maintainer response patterns look like -->
 

--- a/guides/reading-a-codebase.md
+++ b/guides/reading-a-codebase.md
@@ -1,6 +1,6 @@
 # Reading a codebase
 
-Before you change a line of code in an unfimiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
+Before you change a line of code in an unfamiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
 
 This guide is about the first 30 minutes you spend in a new repo.
 

--- a/guides/your-first-pr-checklist.md
+++ b/guides/your-first-pr-checklist.md
@@ -2,7 +2,7 @@
 
 Before you click "Create pull request," walk through this checklist. It catches the things that turn a clean merge into three rounds of review.
 
-## Pre-flight: before comitting
+## Pre-flight: before committing
 
 ### The change itself
 


### PR DESCRIPTION
## Summary
- Fix the five issue-reported typos in README.md and the first-contributor guides.
- Covers `contibution`, `developpers`, `responsivness`, `unfimiliar`, and `comitting`.

## Verification
- `rg -n 'contibution|developpers|responsivness|unfimiliar|comitting' README.md guides` returned no matches.
- `git diff --check` passed.

## Issue reference
Closes #1
Closes #2
Closes #3
Closes #4
Closes #5

## Did you follow CONTRIBUTING.md?
- [ ] I claimed the issue in a comment before starting
- [x] My commit messages are clear and use the imperative form
- [x] My change does only what the issue asked for -- no unrelated edits