### PR TITLE
Fix multiple typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # learn
 
-> Your guide to making your first open source contibution.
+> Your guide to making your first open source contribution.
 
-Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developpers go from "I've never merged a PR" to "I just shipped my first contribution."
+Open source can feel like a closed club. It isn't — but the door is hard to find. This repo is a curated, community-maintained set of resources that help developers go from "I've never merged a PR" to "I just shipped my first contribution."
 
 ## What this repo is
 

--- a/guides/finding-good-first-issues.md
+++ b/guides/finding-good-first-issues.md
@@ -59,7 +59,7 @@ Issues with recent comments are safer.
 
 If the repo has no `CONTRIBUTING.md`, no PR template, and no obvious signs anyone has thought about new contributors, you're on your own. That's fine when you're more experienced — for a first PR, prefer repos that have done some of this work.
 
-### Maintainer responsivness
+### Maintainer responsiveness
 
 <!-- TODO: contribution welcome — expand on what good vs slow maintainer response patterns look like -->
 

--- a/guides/reading-a-codebase.md
+++ b/guides/reading-a-codebase.md
@@ -1,6 +1,6 @@
 # Reading a codebase
 
-Before you change a line of code in an unfimiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
+Before you change a line of code in an unfamiliar codebase, you need to orient yourself. This is the single most underrated skill in open source — and it's the difference between a PR that gets merged and a PR that gets a polite "this isn't quite how we do things here."
 
 This guide is about the first 30 minutes you spend in a new repo.
 

--- a/guides/your-first-pr-checklist.md
+++ b/guides/your-first-pr-checklist.md
@@ -2,7 +2,7 @@
 
 Before you click "Create pull request," walk through this checklist. It catches the things that turn a clean merge into three rounds of review.
 
-## Pre-flight: before comitting
+## Pre-flight: before committing
 
 ### The change itself
 


### PR DESCRIPTION
Fixes 5 typos across 4 documentation files:
- comitting -> committing (your-first-pr-checklist.md)
- unfimiliar -> unfamiliar (reading-a-codebase.md)
- responsivness -> responsiveness (finding-good-first-issues.md)
- developpers -> developers (README.md)
- contibution -> contribution (README.md)

Closes #1, #2, #3, #4, #5